### PR TITLE
[fr33m0nk]: Fixes issue with `typesense.client/multi-search`

### DIFF
--- a/src/typesense/client.clj
+++ b/src/typesense/client.clj
@@ -139,7 +139,7 @@
 
 (defn multi-search
   "Search for documents in multiple collections."
-  [settings search-reqs common-search-params & opt-query-params]
+  [settings search-reqs common-search-params & {:as opt-query-params}]
   (try-typesense-api
    (let [{:keys [uri req]} (api/multi-search-req settings search-reqs common-search-params opt-query-params)]
      (util/http-response-json->map (http/post uri req)))))


### PR DESCRIPTION
* Passing of `opt-query-params` as rest params would cause issue while building payload as the map passed in `opt-query-params` would be wrapped in a sequence