### PR TITLE
fixes issue with test failing on different environments

### DIFF
--- a/test/typesense/client_test.clj
+++ b/test/typesense/client_test.clj
@@ -1,5 +1,6 @@
 (ns ^:integration typesense.client-test
   (:require [typesense.client :as sut]
+            [clojure.set :as set]
             [clojure.test :as t :refer [deftest is testing]]))
 
 (def settings {:uri "http://localhost:8108"
@@ -735,37 +736,22 @@
   (testing "Getting metrics information"
     ;; Compare just the keys, the values change everytime the endpoint is called.
     (let [res (sut/metrics settings)
-          exp [:system_cpu8_active_percentage
-               :system_cpu12_active_percentage
-               :typesense_memory_allocated_bytes
-               :system_cpu5_active_percentage
-               :system_network_sent_bytes
-               :system_cpu3_active_percentage
-               :system_cpu9_active_percentage
-               :typesense_memory_resident_bytes
-               :system_cpu_active_percentage
-               :system_memory_used_bytes
-               :system_cpu14_active_percentage
-               :system_cpu15_active_percentage
-               :system_cpu6_active_percentage
-               :system_cpu10_active_percentage
-               :system_network_received_bytes
-               :system_cpu13_active_percentage
-               :system_cpu11_active_percentage
-               :system_disk_total_bytes
-               :typesense_memory_metadata_bytes
-               :system_cpu4_active_percentage
-               :system_cpu16_active_percentage
-               :typesense_memory_fragmentation_ratio
-               :system_disk_used_bytes
-               :system_memory_total_bytes
-               :typesense_memory_mapped_bytes
-               :system_cpu2_active_percentage
-               :system_cpu1_active_percentage
-               :typesense_memory_retained_bytes
-               :system_cpu7_active_percentage
-               :typesense_memory_active_bytes]]
-      (is (= (keys res) exp))))
+          exp #{:system_cpu1_active_percentage
+                :typesense_memory_allocated_bytes
+                :system_network_sent_bytes
+                :typesense_memory_resident_bytes
+                :system_cpu_active_percentage
+                :system_memory_used_bytes
+                :system_network_received_bytes
+                :system_disk_total_bytes
+                :typesense_memory_metadata_bytes
+                :typesense_memory_fragmentation_ratio
+                :system_disk_used_bytes
+                :system_memory_total_bytes
+                :typesense_memory_mapped_bytes
+                :typesense_memory_retained_bytes
+                :typesense_memory_active_bytes}]
+      (is (set/subset? exp (set (keys res))))))
 
   (testing "Getting stats from a Typesense node"
     ;; Compare just the keys, the values might change everytime the endpoint is called.


### PR DESCRIPTION
Fixes issue where not the same amount of CPU cores was returned from the endpoint resulting in metrics information test failing.