### PR TITLE
now generates a POM file and uses deps deploy instead of corfield build

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -1,24 +1,61 @@
 (ns build
-  (:require [clojure.tools.build.api :as b]
-            [org.corfield.build :as bb]))
+  (:require [clojure.string :as str]
+            [clojure.tools.build.api :as b]
+            [deps-deploy.deps-deploy :as d]
+            [clojure.tools.deps :as t]))
 
 (def lib 'io.github.runeanielsen/typesense-clj)
 (def version (format "0.1.%s" (b/git-count-revs nil)))
+(def class-dir "target/classes")
+(def jar-file (format "target/%s-%s.jar" (name lib) version))
 
-(defn build "Build the JAR." [opts]
-  (-> opts
-      (assoc :lib lib :version version)
-      (bb/clean)
-      (bb/jar)))
+;; delay to defer side effects (artifact downloads)
+(def basis (delay (b/create-basis {:project "deps.edn"})))
 
-(defn tests "Run the tests." [opts]
-  (-> opts
-      (bb/clean)
-      (bb/run-tests)))
+(def pom-template
+  [[:description "Clojure HTTP client for Typesense "]
+   [:url "https://github.com/runeanielsen/typesense-clj/"]
+   [:licenses
+    [:license
+     [:name "MIT"]
+     [:url "https://github.com/runeanielsen/typesense-clj/blob/master/LICENSE"]]]
+   [:developers
+    [:developer
+     [:name "Rune Andreas Nielsen"]]]])
 
-(defn deploy "Deploy the JAR to Clojars." [opts]
-  (-> opts
-      (assoc :lib lib :version version)
-      (bb/clean)
-      (bb/jar)
-      (bb/deploy)))
+(defn- run-task [aliases]
+  (println "\nRunning task for" (str/join "," (map name aliases)))
+  (let [basis    (b/create-basis {:aliases aliases})
+        combined (t/combine-aliases basis aliases)
+        cmds     (b/java-command
+                  {:basis basis
+                   :main 'clojure.main
+                   :main-args (:main-opts combined)})
+        {:keys [exit]} (b/process cmds)]
+    (when-not (zero? exit) (throw (ex-info "Task failed" {})))))
+
+(defn clean []
+  (b/delete {:path "target"}))
+
+(defn build [_]
+  (clean)
+  (b/write-pom {:pom-data pom-template
+                :class-dir class-dir
+                :lib lib
+                :version version
+                :basis @basis
+                :src-dirs ["src"]})
+  (b/copy-dir {:src-dirs ["src" "resources"]
+               :target-dir class-dir})
+  (b/jar {:class-dir class-dir
+          :jar-file jar-file}))
+
+(defn tests [_]
+  (clean)
+  (run-task [:test :runner]))
+
+(defn deploy [_]
+  (clean)
+  (build)
+  (d/deploy {:installer :remote :artifact (b/resolve-path jar-file)
+             :pom-file (b/pom-path {:class-dir class-dir :lib lib})}))

--- a/deps.edn
+++ b/deps.edn
@@ -12,6 +12,8 @@
            {:extra-deps {clj-kondo/config {:git/url "https://github.com/clj-kondo/config"
                                            :sha "bd72d749732540e5e18a9eaca92f507bdb981473"}}
             :main-opts ["-m" "clj-kondo.config"]}
-           :build {:deps {io.github.seancorfield/build-clj {:git/tag "v0.8.0"
-                                                            :git/sha "9bd8b8a"}}
+           :build {:extra-deps
+                   {io.github.clojure/tools.build {:git/tag "v0.10.0"
+                                                   :git/sha "3a2c484"}
+                    slipset/deps-deploy {:mvn/version "0.2.2"}}
                    :ns-default build}}}


### PR DESCRIPTION
`corfield.build` has been deprecated, so we have switched to just using `tools.build` and https://github.com/slipset/deps-deploy for deploying to Clojars.